### PR TITLE
fix: bump version and node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,9 +1391,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.10.tgz",
-      "integrity": "sha512-leUNzbFTMX94TWaIKz8N15Chu55F9QSH+INKayQr5xpkasBQBRF3qQXfo3/dOnMU/dEIit+Y/SU8HyOjq++GwA=="
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
+      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA=="
     },
     "@types/prop-types": {
       "version": "15.7.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OPEN-RPC",
   "publisher": "OPEN-RPC",
   "description": "Provides completion and validation for OPEN-RPC openrpc.json documents",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/open-rpc/editor-extensions-vscode.git"
@@ -67,10 +67,10 @@
     ]
   },
   "devDependencies": {
-    "typescript": "^3.3.4000",
-    "vscode": "^1.1.33",
-    "tslint": "^5.14.0",
+    "@types/mocha": "^5.2.6",
     "@types/node": "^12.0.2",
-    "@types/mocha": "^5.2.6"
+    "tslint": "^5.14.0",
+    "typescript": "^3.3.4000",
+    "vscode": "^1.1.33"
   }
 }


### PR DESCRIPTION
this was needed to publish to `vsce`